### PR TITLE
Mark backing variable for suite property in TestCase as private

### DIFF
--- a/libvaladate/framework/testcase.vala
+++ b/libvaladate/framework/testcase.vala
@@ -53,7 +53,7 @@ namespace Valadate.Framework {
 	 */
 	public abstract class TestCase : Object, Test, TestFixture {
 
-		public GLib.TestSuite _suite;
+		private GLib.TestSuite _suite;
 
 		public GLib.TestSuite suite {
 			get {


### PR DESCRIPTION
This also removes the backing field from the Valadoc documentation