### PR TITLE
Add --hide-internal to VALAFLAGS

### DIFF
--- a/base.am
+++ b/base.am
@@ -17,6 +17,7 @@ VALADATE_VALAFLAGS = \
 	--pkg posix \
 	--pkg config \
 	--target-glib=2.40.0 \
+	--hide-internal \
 	-g
 
 VALADATE_CPPFLAGS = \


### PR DESCRIPTION
--hide-internal adds the C macro G_GNUC_INTERNAL to all
non-public symbols to remove them from the dynamic symbol table
of shared objects